### PR TITLE
Test domyślnych kolumn

### DIFF
--- a/src/main/java/net/sf/keytabgui/util/ConfigSingleton.java
+++ b/src/main/java/net/sf/keytabgui/util/ConfigSingleton.java
@@ -56,6 +56,9 @@ import net.sf.keytabgui.model.column.Timestamp;
  *      has yet to be widely adopted, a single-element enum type is the best way
  *      to implement a singleton.
  * 
+ * 
+ * Another possible place to use Singleton?
+ * Error page ? (when it has to be visible from everywhere?)
  */
 public enum ConfigSingleton {
 	INSTANCE;

--- a/src/main/java/net/sf/keytabgui/util/ConfigSingleton.java
+++ b/src/main/java/net/sf/keytabgui/util/ConfigSingleton.java
@@ -105,10 +105,10 @@ public enum ConfigSingleton {
 	 * 
 	 * @return lista domyslnych nazw klas
 	 */
-	private String getDefaultClassnames() {
-		return "[" + Principal.class.getSimpleName() + ","
-				+ Kvno.class.getSimpleName() + ","
-				+ EncType.class.getSimpleName() + "," + "]";
+	String getDefaultClassnames() {
+		return "[" + Principal.class.getCanonicalName() + ","
+				+ Kvno.class.getCanonicalName() + ","
+				+ EncType.class.getCanonicalName() + "," + "]";
 	}
 
 }

--- a/src/test/java/net/sf/keytabgui/util/TestDefaultConfig.java
+++ b/src/test/java/net/sf/keytabgui/util/TestDefaultConfig.java
@@ -1,0 +1,24 @@
+package net.sf.keytabgui.util;
+
+import static org.junit.Assert.*;
+import net.sf.keytabgui.model.Column;
+
+import org.junit.Test;
+
+public class TestDefaultConfig {
+	
+	@Test
+	public void testDefaultClassnames() {
+		// given
+		
+		// when
+		String defaultClassNames = ConfigSingleton.INSTANCE.getDefaultClassnames();
+		Column[] columns = ColumnUtils.classnamesToColumns(defaultClassNames);
+		
+		// then
+		for (int i=0; i<columns.length; i++){
+			assertNotNull("Column["+i+"] jest null'em. Nie znaleziono klasy", columns[i]);
+		}
+	}
+
+}


### PR DESCRIPTION
Dodany test domyślnych kolumn.

Aby nie powtórzył się błąd (nie można uruchomić programu, z powodu złej listy domyślnych kolumn - nazwy klas są krótkie/simple, zamiast pełnych), można dodać test, sprawdzający poprawność podanych domyślnych kolumn. Używa on tej samej metody do przekształcenia stringa z nazwami klas do tablicy klas. Jeśli którakolwiek z komórek tablicy będzie nullem, rzuci wyjątek.
